### PR TITLE
Don't override filesystem anymore and normalize cloudcube env vars to AWS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.7.1",
+    "version": "3.0.0",
     "name": "robuust/craft-heroku-internal",
     "description": "Module for internal use with Craft and Heroku",
     "require": {

--- a/src/Module.php
+++ b/src/Module.php
@@ -3,8 +3,6 @@
 namespace robuust\heroku;
 
 use Craft;
-use craft\awss3\Fs;
-use craft\fs\Local;
 use craft\helpers\App;
 use craft\mail\transportadapters\Smtp;
 use craft\queue\Queue;
@@ -55,23 +53,6 @@ class Module extends \yii\base\Module
             ];
 
             Craft::$app->set('mailer', Craft::createObject($config));
-        }
-
-        // If this is the dev environment, use Local filesystem instead of S3
-        if (Craft::$app->env === 'dev' || Craft::$app->env === 'test') {
-            Craft::$container->set(Fs::class, function ($container, $params, $config) {
-                if (empty($config)) {
-                    return new Fs($config);
-                }
-
-                return new Local([
-                    'name' => $config['name'],
-                    'handle' => $config['handle'],
-                    'hasUrls' => $config['hasUrls'],
-                    'url' => "@web/uploads/{$config['handle']}",
-                    'path' => "@webroot/uploads/{$config['handle']}",
-                ]);
-            });
         }
 
         // If the request is a Turbo request and the method is POST


### PR DESCRIPTION
### Changed
- Normalized Cloudcube-provided environment variables to AWS-style names used by the AWS PHP SDK and common Laravel filesystem configuration.
- `CLOUDCUBE_*` values are now mirrored to `AWS_*` equivalents when `AWS_*` is not already set.
- `CLOUDCUBE_URL` now derives and sets `AWS_BUCKET`, `AWS_ENDPOINT`, `AWS_ROOT`, and `AWS_PREFIX`.
- Removed the dev/test container override that replaced S3 filesystems with local filesystems.

### Removed
- Legacy derived output variables `CLOUDCUBE_BUCKET`, `CLOUDCUBE_SUBFOLDER`, and `CLOUDCUBE_HOST` are no longer populated by this module.

### Breaking
- Consumers depending on derived `CLOUDCUBE_BUCKET`, `CLOUDCUBE_SUBFOLDER`, or `CLOUDCUBE_HOST` must migrate to `AWS_BUCKET`, `AWS_ROOT`/`AWS_PREFIX`, and `AWS_ENDPOINT`.
- Dev/test environments no longer automatically switch S3 filesystems to local storage through this module.